### PR TITLE
Sidebar Navigation: Arrow should point to the right when collapsed

### DIFF
--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -87,7 +87,11 @@ export function SidebarNavigation() {
             />
             <MenuItemButton
               text="Collapse"
-              iconSrc="/icons/arrow-left.svg"
+              iconSrc={
+                isSidebarCollapsed
+                  ? "/icons/arrow-right.svg"
+                  : "/icons/arrow-left.svg"
+              }
               isCollapsed={isSidebarCollapsed}
               onClick={() => toggleSidebar()}
               className={styles.collapseMenuItem}

--- a/public/icons/arrow-right.svg
+++ b/public/icons/arrow-right.svg
@@ -1,0 +1,5 @@
+<svg style="transform: rotate(180deg)" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M19 12H5M5 12L12 19M5 12L12 5" stroke="#D0D5DD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>
+
+


### PR DESCRIPTION
created a rotated image of the original arrow-left icon as a seperate svg file, then toggled between each icon depending on the collapse react state.